### PR TITLE
Fix boost sha1.hpp include path

### DIFF
--- a/include/util/meid_converter.h
+++ b/include/util/meid_converter.h
@@ -29,7 +29,7 @@
 #include "definitions.h"
 #include <iostream>
 #include <sstream>
-#include <boost/uuid/sha1.hpp>
+#include <boost/uuid/detail/sha1.hpp>
 #include "util/string_helper.h"
 
 enum MeidConverterInputType {


### PR DESCRIPTION
Latest boost version has a different path, and was failing to build